### PR TITLE
Add ChangeId to PublicStashTabSubscriptionResult

### DIFF
--- a/api/public_stash_tab_subscription.go
+++ b/api/public_stash_tab_subscription.go
@@ -77,7 +77,7 @@ func (s *PublicStashTabSubscription) run(firstChangeId string) {
 					Error:    err,
 				}
 				continue
-			}			
+			}
 
 			if len(tabs.Stashes) > 0 {
 				s.Channel <- PublicStashTabSubscriptionResult{
@@ -85,7 +85,7 @@ func (s *PublicStashTabSubscription) run(firstChangeId string) {
 					PublicStashTabs: tabs,
 				}
 			}
-			
+
 			nextChangeId = tabs.NextChangeId
 		}
 	}

--- a/api/public_stash_tab_subscription.go
+++ b/api/public_stash_tab_subscription.go
@@ -8,6 +8,7 @@ import (
 )
 
 type PublicStashTabSubscriptionResult struct {
+	ChangeId        string
 	PublicStashTabs *PublicStashTabs
 	Error           error
 }
@@ -61,7 +62,8 @@ func (s *PublicStashTabSubscription) run(firstChangeId string) {
 			response, err := http.Get("https://" + s.host + "/api/public-stash-tabs?id=" + url.QueryEscape(nextChangeId))
 			if err != nil {
 				s.Channel <- PublicStashTabSubscriptionResult{
-					Error: err,
+					ChangeId: nextChangeId,
+					Error:    err,
 				}
 				continue
 			}
@@ -71,7 +73,8 @@ func (s *PublicStashTabSubscription) run(firstChangeId string) {
 			err = decoder.Decode(tabs)
 			if err != nil {
 				s.Channel <- PublicStashTabSubscriptionResult{
-					Error: err,
+					ChangeId: nextChangeId,
+					Error:    err,
 				}
 				continue
 			}
@@ -80,6 +83,7 @@ func (s *PublicStashTabSubscription) run(firstChangeId string) {
 
 			if len(tabs.Stashes) > 0 {
 				s.Channel <- PublicStashTabSubscriptionResult{
+					ChangeId:        nextChangeId,
 					PublicStashTabs: tabs,
 				}
 			}

--- a/api/public_stash_tab_subscription.go
+++ b/api/public_stash_tab_subscription.go
@@ -77,9 +77,7 @@ func (s *PublicStashTabSubscription) run(firstChangeId string) {
 					Error:    err,
 				}
 				continue
-			}
-
-			nextChangeId = tabs.NextChangeId
+			}			
 
 			if len(tabs.Stashes) > 0 {
 				s.Channel <- PublicStashTabSubscriptionResult{
@@ -87,6 +85,8 @@ func (s *PublicStashTabSubscription) run(firstChangeId string) {
 					PublicStashTabs: tabs,
 				}
 			}
+			
+			nextChangeId = tabs.NextChangeId
 		}
 	}
 }


### PR DESCRIPTION
This enables components using the library to to store where they "left off" at the last run.